### PR TITLE
Adding page on past NeuroML events

### DIFF
--- a/source/Events/PastEvents.md
+++ b/source/Events/PastEvents.md
@@ -1,0 +1,6 @@
+(neuromlevents:past)=
+# Past NeuroML Events
+
+A number of developer workshops and editorial board meetings have been held since 2008 to coordinate and promote the work of the NeuroML community. These are listed [here](https://neuroml.org/workshops).
+
+There has been significant NeuroML involvement also at the meetings organised by the Open Source Brain initiative. See [here](https://www.opensourcebrain.org/docs#Meetings) for more details.

--- a/source/_toc.yml
+++ b/source/_toc.yml
@@ -60,6 +60,7 @@ parts:
       - file: Events/202108-INCF-Training-Week
       - file: Events/202107-CNS2021
       - file: Events/202103-Harmony
+      - file: Events/PastEvents
   - caption: The NeuroML Initiative
     chapters:
       - file: NeuroMLOrg/CommunicationChannels


### PR DESCRIPTION
Actual content/pdfs from the meetings page can be copied over at a later date...