### PR TITLE
fix(history): remove repeated text

### DIFF
--- a/source/NeuroMLOrg/History.md
+++ b/source/NeuroMLOrg/History.md
@@ -39,7 +39,8 @@ More details on the structure of LEMS and how it is used in NeuroML2 can be foun
 
 In parallel with development of NeuroML2 and LEMS, software libraries for reading, writing and running simulations using the languages are under active development in Java ({ref}`jNeuroML <jNeuroML>`) and Python ({ref}`libNeuroML <libNeuroML>` and {ref}`pyLEMS <pyLEMS>` (see Vella et al. 2014 {cite}`Vella2014`) and {ref}`pyNeuroML <pyNeuroML>`).
 
-The NeuroML specifications are currently being developed by the {ref}`NeuroML Editorial Board <neuromlorg:board>`, overseen by the NeuroML specifications are developed by the {ref}`NeuroML Editorial Board <neuromlorg:board>` and overseen by its {ref}`Scientific Committee <neuromlorg:ScientificCommittee>`. NeuroML specifications and the associated libraries are developed on GitHub and an overview of current activities can be found [here](https://github.com/NeuroML/NeuroML2/projects/1).
+The NeuroML specifications are developed by the {ref}`NeuroML Editorial Board <neuromlorg:board>` and overseen by its {ref}`Scientific Committee <neuromlorg:ScientificCommittee>`.
+NeuroML specifications and the associated libraries are developed on GitHub and an overview of current activities can be found [here](https://github.com/NeuroML/NeuroML2/projects/1).
 
 
 ```{admonition} Recent releases of NeuroML2


### PR DESCRIPTION

To remove repeated text from your history, you can use the following steps:

Open the history file.

Sort the lines in the file by date.

Remove any duplicate lines.

Save the file.

Here are the specific steps for each of the above:

1. Open the history file.

The history file is typically located in the following directory:

Code snippet

/home/[username]/.bash_history 

You can open the file using a text editor, such as Nano or Vim.

2. Sort the lines in the file by date.

Once you have opened the file, you can sort the lines by date using the following command:

Code snippet

sort -k1,1 -n 

This will sort the lines by the first column, which is the date.

3. Remove any duplicate lines.

Once the lines are sorted, you can remove any duplicate lines using the following command:

Code snippet

uniq 

This will remove any lines that are identical to the previous line.

4. Save the file.

Once you have removed the duplicate lines, you can save the file using the following command:

Code snippet

wq 

This will save the file and quit the text editor.

Here is an example of how to remove repeated text from your history:

Code snippet

$ history | sort -k1,1 -n | uniq > new_history 

This will create a new file called new_history that contains all of the unique lines from the original history file.

You can then replace the original history file with the new one by using the following command:

Code snippet

mv new_history .bash_history 

This will move the new history file to the location of the original history file and rename it.

Once you have done this, you will no longer have any duplicate lines in your history.
Yes, there are a few things you can do to improve the code above.

First, you can use the `-u` option with the `uniq` command to remove duplicates without creating a new file. This will make the code more efficient and less wasteful of resources.

Second, you can use the `-r` option with the `sort` command to sort the lines in reverse order. This will ensure that the most recent commands are removed first, which is usually what you want.

Finally, you can use the `-n` option with the `sort` command to sort the lines numerically. This will ensure that the lines are sorted by date, which is the most logical way to sort them.

Here is the improved code:

Code snippet
history | sort -rnk1,1 | uniq -u
Use code with caution. Learn more
This code will remove duplicate lines from your history file without creating a new file, and it will sort the lines in reverse chronological order.
The code uses the `history`, `sort`, and `uniq` commands to remove duplicate lines from the history file. The `history` command prints the history of commands that have been run in the current shell. The `sort` command sorts the lines of input. The `-k1,1` option specifies that the lines should be sorted by the first column, which is the date. The `-n` option specifies that the lines should be sorted numerically. The `uniq` command removes duplicate lines from input. The `-u` option specifies that only unique lines should be output.

The following is a step-by-step overview of how the code works:

1. The `history` command prints the history of commands that have been run in the current shell.
2. The `sort` command sorts the lines of input. The `-k1,1` option specifies that the lines should be sorted by the first column, which is the date. The `-n` option specifies that the lines should be sorted numerically.
3. The `uniq` command removes duplicate lines from input. The `-u` option specifies that only unique lines should be output.

The output of the code is a list of unique lines from the history file, sorted in reverse chronological order.